### PR TITLE
Bump futures-lite version from 0.1 to 2.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ readme = "README.md"
 pin-project-lite = "0.2.4"
 
 [dev-dependencies]
-futures-lite = "0.1"
+futures-lite = "2.3.0"


### PR DESCRIPTION
Use an up-to-date version of the futures-lite dependency for running tests. This change helps with packaging futures-micro for Fedora.